### PR TITLE
fix: set site URL to imbra-soft.com

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,6 @@ import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  site: 'https://imbra-ltd.github.io',
+  site: 'https://imbra-soft.com',
   integrations: [react(), sitemap()],
 });


### PR DESCRIPTION
## Problem
`astro.config.mjs` had `site: 'https://imbra-ltd.github.io'` which caused `og:image` meta tags to point to the wrong domain. That URL redirects to `http://imbra-soft.com` — the redirect chain breaks Viber (and other) OG scrapers.

## Fix
Set `site` to `https://imbra-soft.com` so canonical URLs and `og:image` resolve directly.

## Note
Will need updating again once domain migrates to `imbra.io` (tracked in #29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)