### PR TITLE
fix: correct brand name casing to Imbra.Soft

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
-# Imbra.soft Website — Claude Code Instructions
+# Imbra.Soft Website — Claude Code Instructions
 
 ## Project
-Website for Imbra.soft (imbra-soft.com) — a boutique software and industrial engineering consultancy based in Varna, Bulgaria.
+Website for Imbra.Soft (imbra-soft.com) — a boutique software and industrial engineering consultancy based in Varna, Bulgaria.
 
 - Owner: Branimir Georgiev
 - GitHub org: https://github.com/Imbra-Ltd
@@ -30,7 +30,7 @@ Website for Imbra.soft (imbra-soft.com) — a boutique software and industrial e
 ## Brand voice
 - Tagline: "Complex inside. Simple outside."
 - Tone: precise, direct, no marketing fluff, no adjective inflation
-- Use "Imbra.soft" in body copy — not "Imbra Ltd", not "IMBRA.SOFT"
+- Use "Imbra.Soft" in body copy — not "Imbra Ltd", not "IMBRA.SOFT"
 - Logo renders as: `IMBRA<span>.</span>SOFT` in IBM Plex Mono
 
 ## Content

--- a/src/components/Expertise.astro
+++ b/src/components/Expertise.astro
@@ -5,7 +5,7 @@ const { expertise } = Astro.props;
   <div class="reveal">
     <div class="section-label">03 — Domain Expertise</div>
     <h2 class="section-heading">Where our <strong>knowledge runs deep</strong></h2>
-    <p class="section-sub">Imbra.soft works in domains that demand real engineering experience — not generalist consultancy.</p>
+    <p class="section-sub">Imbra.Soft works in domains that demand real engineering experience — not generalist consultancy.</p>
   </div>
   <div class="reveal">
     <div class="expertise-grid">

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -3,8 +3,8 @@ import HamburgerMenu from "./interactive/HamburgerMenu.tsx";
 const { links, cta } = Astro.props;
 ---
 <nav>
-  <a class="nav-logo" href="/" aria-label="Imbra.soft — home">
-    <img src="/logos/logo-1b-web.svg" alt="Imbra.soft" class="nav-logo-img" />
+  <a class="nav-logo" href="/" aria-label="Imbra.Soft — home">
+    <img src="/logos/logo-1b-web.svg" alt="Imbra.Soft" class="nav-logo-img" />
   </a>
   <div class="nav-links">
     {links.map((l: { label: string; target: string }) => (

--- a/src/data/services.json
+++ b/src/data/services.json
@@ -58,7 +58,7 @@
     ],
     "projects": [
       "Protocol Emulator Framework · Hilscher",
-      "ImBrain Core Historian · Imbra.soft",
+      "ImBrain Core Historian · Imbra.Soft",
       "Data Integration Agents · Heidelberg Materials",
       "PxTrend Historian · Heidelberg Materials"
     ]
@@ -164,7 +164,7 @@
     "num": "10",
     "title": "Training & Tutorials",
     "desc": "Practical courses and tutorials for engineers working at the OT/IT boundary — industrial protocols, PLC/DCS programming, historian architecture, testing methodologies, and applied AI/ML. Published on Udemy, YouTube, and dedicated course pages.",
-    "detail": "Content is built around real industrial problems encountered across automation, connectivity, and software engineering projects — not synthetic examples.\n\nTopics covered include industrial communication protocols, PLC/DCS programming with Siemens platforms, OT/IT integration and historian architecture, emulator-based testing and specification-driven QA, and applied AI/ML for predictive maintenance and engineering tooling.\n\nPublished as structured video courses on Udemy, free tutorials and walkthroughs on YouTube, and written guides on the Imbra.soft blog. New content released as projects generate material worth sharing.",
+    "detail": "Content is built around real industrial problems encountered across automation, connectivity, and software engineering projects — not synthetic examples.\n\nTopics covered include industrial communication protocols, PLC/DCS programming with Siemens platforms, OT/IT integration and historian architecture, emulator-based testing and specification-driven QA, and applied AI/ML for predictive maintenance and engineering tooling.\n\nPublished as structured video courses on Udemy, free tutorials and walkthroughs on YouTube, and written guides on the Imbra.Soft blog. New content released as projects generate material worth sharing.",
     "tech": ["Udemy", "YouTube", "Siemens TIA Portal", "OPC-UA", "Modbus", "Python", "AI/ML"]
   }
 ]

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "title": "Imbra.soft — Software & Industrial Engineering",
-    "description": "Imbra.soft builds software products and delivers engineering services for industrial environments."
+    "title": "Imbra.Soft — Software & Industrial Engineering",
+    "description": "Imbra.Soft builds software products and delivers engineering services for industrial environments."
   },
   "nav": {
     "links": [
@@ -16,7 +16,7 @@
     "eyebrow": "Software & Industrial Engineering",
     "headline": "Complex inside.",
     "headlineStrong": "Simple outside.",
-    "sub": "Imbra.soft builds software products and delivers engineering services for industrial environments — absorbing the technical complexity so operators, engineers, and clients get interfaces and tools that simply work.",
+    "sub": "Imbra.Soft builds software products and delivers engineering services for industrial environments — absorbing the technical complexity so operators, engineers, and clients get interfaces and tools that simply work.",
     "cta": { "label": "View Portfolio", "target": "portfolio" },
     "ghost": { "label": "Discuss a project →", "target": "contact" },
     "stats": [
@@ -72,8 +72,8 @@
       "github": "github.com/Imbra-Ltd",
       "githubHref": "https://github.com/Imbra-Ltd"
     },
-    "about": "Imbra.soft is a boutique software and industrial engineering consultancy based in Varna, Bulgaria. We specialise in OT/IT integration, industrial historian systems, communication protocol SDKs, and bespoke engineering services — serving industrial businesses that need production-grade engineering without enterprise overhead.",
-    "copy": "© 2026 Imbra.soft · All rights reserved",
+    "about": "Imbra.Soft is a boutique software and industrial engineering consultancy based in Varna, Bulgaria. We specialise in OT/IT integration, industrial historian systems, communication protocol SDKs, and bespoke engineering services — serving industrial businesses that need production-grade engineering without enterprise overhead.",
+    "copy": "© 2026 Imbra.Soft · All rights reserved",
     "builtWith": "Built with Claude Code"
   }
 }

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -27,7 +27,7 @@ const ogImageURL = new URL(ogImage, Astro.site);
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:image" content={ogImageURL} />
-    <meta property="og:site_name" content="Imbra.soft" />
+    <meta property="og:site_name" content="Imbra.Soft" />
     <meta property="og:locale" content="en_GB" />
 
     <!-- Twitter card -->

--- a/src/pages/courses/index.astro
+++ b/src/pages/courses/index.astro
@@ -2,7 +2,7 @@
 import Base from "../../layouts/Base.astro";
 import site from "../../data/site.json";
 ---
-<Base title={`Courses — ${site.meta.title}`} description="Upcoming courses from Imbra.soft.">
+<Base title={`Courses — ${site.meta.title}`} description="Upcoming courses from Imbra.Soft.">
   <main style="padding: 120px 48px; font-family: 'IBM Plex Sans', sans-serif;">
     <p style="font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: #1B4F8A; letter-spacing: 0.15em; text-transform: uppercase; margin-bottom: 24px;">Coming soon</p>
     <h1 style="font-size: 40px; font-weight: 300; color: #111318; letter-spacing: -0.02em;">Courses</h1>


### PR DESCRIPTION
## Summary
Replaces all instances of `Imbra.soft` with `Imbra.Soft` across src/, data files, and CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)