### PR TITLE
feat: migrate primary domain to imbra.io

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,13 @@
 # Imbra.Soft Website — Claude Code Instructions
 
 ## Project
-Website for Imbra.Soft (imbra-soft.com) — a boutique software and industrial engineering consultancy based in Varna, Bulgaria.
+Website for Imbra.Soft (imbra.io) — a boutique software and industrial engineering consultancy based in Varna, Bulgaria.
 
 - Owner: Branimir Georgiev
 - GitHub org: https://github.com/Imbra-Ltd
-- Contact: contact@imbra-soft.com
+- Contact: contact@imbra.io
 - LinkedIn: https://linkedin.com/in/branimir-georgiev
-- Deployed to GitHub Pages at https://imbra-ltd.github.io via GitHub Actions on push to `main`
+- Deployed to GitHub Pages at https://imbra.io via GitHub Actions on push to `main`
 
 ## Stack
 - Astro (static site generator, output: static / GitHub Pages)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Imbra.Soft | Software & Industrial Engineering
 
-Website for [Imbra.Soft](https://imbra-soft.com) — a boutique software and industrial engineering consultancy based in Varna, Bulgaria.
+Website for [Imbra.Soft](https://imbra.io) — a boutique software and industrial engineering consultancy based in Varna, Bulgaria.
 
 ## Getting started
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,6 @@ import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  site: 'https://imbra-soft.com',
+  site: 'https://imbra.io',
   integrations: [react(), sitemap()],
 });

--- a/src/data/pricing.json
+++ b/src/data/pricing.json
@@ -174,6 +174,6 @@
     "heading": "Not sure which model fits?",
     "sub": "Describe your situation and we will recommend the right engagement type.",
     "label": "Get in touch",
-    "email": "contact@imbra-soft.com"
+    "email": "contact@imbra.io"
   }
 }

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -49,7 +49,7 @@
     "headlineStrong": "ours to solve.",
     "sub": "Project engagements · Plugin services · Maintenance contracts",
     "cta": "Get in touch",
-    "email": "contact@imbra-soft.com"
+    "email": "contact@imbra.io"
   },
   "footer": {
     "legal": [
@@ -71,7 +71,7 @@
     ],
     "address": {
       "city": "Varna, Bulgaria",
-      "email": "contact@imbra-soft.com",
+      "email": "contact@imbra.io",
       "github": "github.com/Imbra-Ltd",
       "githubHref": "https://github.com/Imbra-Ltd"
     },

--- a/src/pages/imprint.astro
+++ b/src/pages/imprint.astro
@@ -35,7 +35,7 @@ import site from "../data/site.json";
       <div class="legal-section">
         <div class="legal-section-title">Contact</div>
         <div class="legal-section-body">
-          <p><a href="mailto:contact@imbra-soft.com">contact@imbra-soft.com</a></p>
+          <p><a href="mailto:contact@imbra.io">contact@imbra.io</a></p>
         </div>
       </div>
 

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -20,7 +20,7 @@ import site from "../data/site.json";
         <div class="legal-section-title">Controller</div>
         <div class="legal-section-body">
           <p>Imbra OOD<br />ul. Tsar Simeon I 36<br />Varna, Bulgaria</p>
-          <p><a href="mailto:contact@imbra-soft.com">contact@imbra-soft.com</a></p>
+          <p><a href="mailto:contact@imbra.io">contact@imbra.io</a></p>
         </div>
       </div>
 
@@ -45,7 +45,7 @@ import site from "../data/site.json";
         <div class="legal-section-title">Your rights</div>
         <div class="legal-section-body">
           <p>Under the General Data Protection Regulation (GDPR), you have the right to access, rectify, or erase any personal data we hold about you, as well as the right to restrict or object to its processing.</p>
-          <p>To exercise these rights, contact us at <a href="mailto:contact@imbra-soft.com">contact@imbra-soft.com</a>.</p>
+          <p>To exercise these rights, contact us at <a href="mailto:contact@imbra.io">contact@imbra.io</a>.</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Update `astro.config.mjs` site URL → `https://imbra.io` (fixes OG image and canonical URLs)
- Update all email addresses → `contact@imbra.io`
- Update `README.md` and `CLAUDE.md` domain references

Closes #29

## Test plan
- [ ] Site loads at https://imbra.io
- [ ] OG image resolves correctly from imbra.io
- [ ] Email links point to contact@imbra.io
- [ ] Sitemap generates with imbra.io URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)