### PR TITLE
fix: remove ImBrain reference from services project list

### DIFF
--- a/src/data/services.json
+++ b/src/data/services.json
@@ -28,7 +28,6 @@
     ],
     "projects": [
       "Protocol Emulator Framework · Hilscher",
-      "ImBrain Core Historian · Imbra",
       "Data Integration Agents · Heidelberg Materials",
       "PxTrend Historian · Heidelberg Materials"
     ]


### PR DESCRIPTION
## Summary
- Removed "ImBrain Core Historian · Imbra" from the Software Services & SDKs project list — keeps ImBrain references off the public services section

## Test plan
- [x] Verify Software Services & SDKs project list no longer mentions ImBrain

🤖 Generated with [Claude Code](https://claude.com/claude-code)