### PR TITLE
fix: add bold emphasis to Process section heading

### DIFF
--- a/src/components/Process.astro
+++ b/src/components/Process.astro
@@ -7,7 +7,7 @@ const { process } = Astro.props as Props;
 ---
 <section id="process" class="reveal">
   <div class="section-label">{process.label}</div>
-  <h2 class="section-heading">{process.heading}</h2>
+  <h2 class="section-heading">From first contact to <strong>long-term support.</strong></h2>
   <p class="section-sub">{process.sub}</p>
 
   <div class="process-steps">

--- a/src/data/process.json
+++ b/src/data/process.json
@@ -1,6 +1,5 @@
 {
   "label": "03 — How We Work",
-  "heading": "From first contact to long-term support.",
   "sub": "Every engagement follows a clear, documented sequence. You always know what phase you are in, what comes next, and what it will cost.",
   "steps": [
     {


### PR DESCRIPTION
## Summary
- Process section heading now uses `<strong>` for the final phrase, matching the visual style of Services, Expertise, and Publications sections
- Removed unused `heading` field from `process.json`

## Test plan
- [x] Verify Process section heading renders "From first contact to **long-term support.**" with bold on the last part
- [x] Verify style matches other section headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)