### PR TITLE
fix: widescreen layout, hero zoom balance, and contact form validation

### DIFF
--- a/src/components/interactive/ContactForm.tsx
+++ b/src/components/interactive/ContactForm.tsx
@@ -47,7 +47,7 @@ export default function ContactForm({ endpoint }: Props) {
   }
 
   return (
-    <form className="contact-form" onSubmit={handleSubmit} noValidate>
+    <form className="contact-form" onSubmit={handleSubmit}>
       <div className="contact-form-row">
         <div className="contact-form-field">
           <label htmlFor="cf-name">Name</label>
@@ -79,6 +79,7 @@ export default function ContactForm({ endpoint }: Props) {
         <label htmlFor="cf-message">Message</label>
         <textarea id="cf-message" name="message" rows={4} required />
       </div>
+      <input type="text" name="_gotcha" style={{ display: "none" }} tabIndex={-1} autoComplete="off" />
       {status === "error" && (
         <p className="contact-form-error">{errorMsg}</p>
       )}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -79,7 +79,7 @@ nav {
 /* ── Hero ── */
 .hero { display: flex; flex-direction: column; border-bottom: 1px solid var(--color-border); padding-top: 60px; background: var(--color-white); }
 .hero-left { padding: 80px max(48px, calc((100% - var(--page-max-width)) / 2)) 48px; display: flex; flex-direction: row; align-items: center; gap: 48px; }
-.hero-left-content { display: flex; flex-direction: column; justify-content: center; flex: 1; }
+.hero-left-content { display: flex; flex-direction: column; justify-content: center; width: 520px; max-width: 100%; flex-shrink: 0; }
 .hero-image { flex: 1; min-width: 0; display: flex; align-items: center; justify-content: flex-end; }
 .hero-image img { width: 100%; max-height: 100%; height: auto; object-fit: contain; display: block; }
 .hero-eyebrow { font-family: 'IBM Plex Mono', monospace; font-size: 11px; font-weight: 500; color: var(--color-accent); letter-spacing: 0.15em; text-transform: uppercase; margin-bottom: 24px; display: flex; align-items: center; gap: 12px; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,8 @@
 
 /* ── Design tokens ── */
 :root {
+  --page-max-width:       1440px;
+
   --color-white:          #FFFFFF;
   --color-bg:             #F8F9FA;
   --color-dark:           #111318;
@@ -50,7 +52,7 @@ nav {
   position: fixed; top: 0; left: 0; right: 0; z-index: 100;
   background: rgba(248,249,250,0.92); backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--color-border); height: 60px;
-  display: flex; align-items: center; padding: 0 48px; justify-content: space-between;
+  display: flex; align-items: center; padding: 0 max(48px, calc((100% - var(--page-max-width)) / 2)); justify-content: space-between;
 }
 .nav-logo { display: flex; align-items: center; cursor: pointer; text-decoration: none; }
 .nav-logo-img { height: 40px; width: auto; display: block; }
@@ -76,9 +78,9 @@ nav {
 
 /* ── Hero ── */
 .hero { display: flex; flex-direction: column; border-bottom: 1px solid var(--color-border); padding-top: 60px; background: var(--color-white); }
-.hero-left { padding: 80px 48px 48px 48px; display: flex; flex-direction: row; align-items: center; gap: 48px; }
-.hero-left-content { display: flex; flex-direction: column; justify-content: center; max-width: 520px; flex-shrink: 0; }
-.hero-image { flex: 1; display: flex; align-items: center; justify-content: flex-end; }
+.hero-left { padding: 80px max(48px, calc((100% - var(--page-max-width)) / 2)) 48px; display: flex; flex-direction: row; align-items: center; gap: 48px; }
+.hero-left-content { display: flex; flex-direction: column; justify-content: center; flex: 1; }
+.hero-image { flex: 1; min-width: 0; display: flex; align-items: center; justify-content: flex-end; }
 .hero-image img { width: 100%; max-height: 100%; height: auto; object-fit: contain; display: block; }
 .hero-eyebrow { font-family: 'IBM Plex Mono', monospace; font-size: 11px; font-weight: 500; color: var(--color-accent); letter-spacing: 0.15em; text-transform: uppercase; margin-bottom: 24px; display: flex; align-items: center; gap: 12px; }
 .hero-eyebrow::before { content: ''; width: 24px; height: 1px; background: var(--color-accent); }
@@ -92,7 +94,7 @@ nav {
 .btn-ghost { background: none; color: var(--color-dark); font-family: 'IBM Plex Sans', sans-serif; font-size: 14px; font-weight: 400; padding: 14px 0; border: none; border-bottom: 1px solid var(--color-dark); cursor: pointer; letter-spacing: 0.02em; display: flex; align-items: center; gap: 8px; transition: color 0.15s; text-decoration: none; }
 .btn-ghost:hover { color: var(--color-accent); border-color: var(--color-accent); }
 .btn-ghost:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 3px; }
-.hero-right { border-top: 1px solid var(--color-border); }
+.hero-right { border-top: 1px solid var(--color-border); padding-left: max(48px, calc((100% - var(--page-max-width)) / 2)); padding-right: max(48px, calc((100% - var(--page-max-width)) / 2)); }
 .hero-stats { display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; }
 .stat-cell { padding: 32px; border-right: 1px solid var(--color-border); background: var(--color-bg); }
 .stat-cell:last-child { border-right: none; }
@@ -101,7 +103,7 @@ nav {
 .stat-sub { font-size: 11px; font-weight: 300; color: var(--color-text-dim); margin-top: 6px; line-height: 1.5; }
 
 /* ── Sections (shared) ── */
-section { padding: 96px 48px; }
+section { padding: 96px max(48px, calc((100% - var(--page-max-width)) / 2)); }
 .section-label { font-family: 'IBM Plex Mono', monospace; font-size: 11px; font-weight: 500; color: var(--color-accent); letter-spacing: 0.15em; text-transform: uppercase; margin-bottom: 48px; display: flex; align-items: center; gap: 16px; }
 .section-label::after { content: ''; flex: 1; height: 1px; background: var(--color-border); }
 .section-heading { font-size: clamp(28px, 3vw, 40px); font-weight: 300; color: var(--color-dark); letter-spacing: -0.02em; line-height: 1.15; margin-bottom: 12px; }
@@ -231,7 +233,7 @@ section { padding: 96px 48px; }
 
 /* ── Footer ── */
 footer { background: var(--color-dark); color: white; }
-.footer-top { border-bottom: 1px solid rgba(255,255,255,0.08); padding: 16px 48px; display: flex; justify-content: space-between; align-items: center; }
+.footer-top { border-bottom: 1px solid rgba(255,255,255,0.08); padding: 16px max(48px, calc((100% - var(--page-max-width)) / 2)); display: flex; justify-content: space-between; align-items: center; }
 .footer-legal { display: flex; gap: 32px; }
 .footer-legal-link { font-family: 'IBM Plex Sans', sans-serif; font-size: 12px; font-weight: 500; color: rgba(255,255,255,0.5); letter-spacing: 0.06em; text-transform: uppercase; text-decoration: none; transition: color 0.15s; }
 .footer-legal-link:hover { color: white; }
@@ -240,7 +242,7 @@ footer { background: var(--color-dark); color: white; }
 .footer-social-link:hover { opacity: 1; }
 .footer-social-link.linkedin { background: var(--color-linkedin); }
 .footer-social-link.github { background: var(--color-github); }
-.footer-body { padding: 40px 48px; display: grid; grid-template-columns: 280px 1fr; gap: 64px; }
+.footer-body { padding: 40px max(48px, calc((100% - var(--page-max-width)) / 2)); display: grid; grid-template-columns: 280px 1fr; gap: 64px; }
 .footer-address .footer-logo { font-family: 'IBM Plex Mono', monospace; font-size: 14px; font-weight: 500; color: white; letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 16px; display: block; }
 .footer-address .footer-logo span { color: var(--color-accent); }
 .footer-address p { font-size: 12px; color: rgba(255,255,255,0.4); font-weight: 300; line-height: 1.9; }
@@ -251,7 +253,7 @@ footer { background: var(--color-dark); color: white; }
 .footer-desc-text a:hover { color: white; }
 .footer-founder-link { font-family: 'IBM Plex Sans', sans-serif; font-size: 13px; font-weight: 500; color: white; text-decoration: none; letter-spacing: 0.01em; margin-top: 20px; display: inline-block; border-bottom: 1px solid rgba(255,255,255,0.3); padding-bottom: 2px; transition: border-color 0.15s; }
 .footer-founder-link:hover { border-color: white; }
-.footer-bottom { border-top: 1px solid rgba(255,255,255,0.06); padding: 16px 48px; display: flex; justify-content: space-between; align-items: center; }
+.footer-bottom { border-top: 1px solid rgba(255,255,255,0.06); padding: 16px max(48px, calc((100% - var(--page-max-width)) / 2)); display: flex; justify-content: space-between; align-items: center; }
 .footer-copy { font-size: 11px; color: rgba(255,255,255,0.2); font-weight: 300; }
 .footer-built-with { font-size: 11px; color: rgba(255,255,255,0.2); font-weight: 300; }
 


### PR DESCRIPTION
## Fixes

- [x] Closes #68 — content stretches full width on ultra-wide screens
- [x] Closes #69 — hero image grows when zooming out, shrinks text column
- [x] Closes #70 — contact form submits with empty fields and closes the form
- [x] Closes #71 — no bot/spam protection on contact form

## Changes

- Add `--page-max-width: 1440px` and `max()` padding formula across nav, sections, hero, and footer so content is capped at 1440px and centered on ultra-wide displays; backgrounds remain full-bleed
- Fix hero zoom balance: set explicit `width: 520px` on text column so it holds its size regardless of font scaling; image retains its original larger proportion
- Remove `noValidate` from the contact form so browser enforces `required` fields before submission
- Add `_gotcha` honeypot field for bot protection, complementing reCAPTCHA already enabled in Formspree

## Test plan

- [x] Open site on a 2K/4K monitor or zoom out to <75% — content should stay centered and capped, not stretch edge to edge
- [x] Zoom in and out on the homepage hero — text column should stay at its fixed width; image fills remaining space as designed
- [x] Submit the contact form with all fields empty — browser should block and highlight the first empty field
- [x] Submit the contact form with all fields filled — should post successfully as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)