### PR TITLE
chore: unlist pricing page (route kept, hidden from nav and search)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ src/components/
 | Page                            | Path                                | Notes                                      |
 |---------------------------------|-------------------------------------|--------------------------------------------|
 | Homepage                        | `/`                                 | All main sections                          |
-| Pricing                         | `/pricing/`                         | Standalone page with contact form          |
+| Pricing (unlisted)              | `/pricing/`                         | Built and reachable by direct URL, but not linked from nav or 404, and `noindex` so search engines skip it |
 | Whitepaper — ImBrain            | `/whitepapers/imbrain/`             | Landing page for ImBrain white paper       |
 | Whitepaper — Imbra Connect      | `/whitepapers/imbra-connect/`       | Landing page for Imbra Connect white paper |
 | Whitepaper — Honeywell/Siemens  | `/whitepapers/honeywell-siemens/`   | Landing page for Honeywell white paper     |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ src/
 │   └── Base.astro         # HTML shell, global CSS, reveal script
 ├── pages/
 │   ├── index.astro        # Homepage
-│   ├── pricing.astro      # Pricing page
+│   ├── pricing.astro      # Pricing page (unlisted — reachable by direct URL, noindex, not in nav)
 │   ├── imprint.astro      # Legal imprint
 │   └── privacy.astro      # Privacy policy
 └── styles/

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,5 +6,5 @@ import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
   site: 'https://imbra.io',
-  integrations: [react(), sitemap()],
+  integrations: [react(), sitemap({ filter: (page) => !page.includes('/pricing') })],
 });

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -8,8 +8,7 @@
       { "label": "Services",   "target": "services" },
       { "label": "Process",    "target": "process" },
       { "label": "Expertise",  "target": "expertise" },
-      { "label": "Research",   "target": "publications" },
-      { "label": "Pricing",    "target": "pricing", "href": "/pricing/" }
+      { "label": "Research",   "target": "publications" }
     ],
     "cta": { "label": "Get in touch", "target": "contact" }
   },

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -21,7 +21,6 @@ import site from "../data/site.json";
         <div class="legal-section-title">Where to go</div>
         <div class="legal-section-body">
           <p><a href="/">imbra.io — Homepage</a></p>
-          <p><a href="/pricing/">Pricing</a></p>
           <p><a href="mailto:contact@imbra.io">contact@imbra.io</a></p>
         </div>
       </div>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -15,6 +15,7 @@ const pricingLinks = [
 ---
 
 <Base title={`${pricing.meta.title} — ${site.meta.title}`} description={pricing.meta.description}>
+  <meta slot="head" name="robots" content="noindex, nofollow" />
   <Nav links={pricingLinks} cta={site.nav.cta} />
 
   <main class="pricing-page">


### PR DESCRIPTION
## Summary
- Keep `/pricing/` reachable by direct URL so it can be shared selectively, but remove every public entry point and tell search engines to skip it while pricing strategy is being reworked.
- Adds `<meta name="robots" content="noindex, nofollow">` to the pricing page and excludes `/pricing` from the generated sitemap so the URL is not advertised to crawlers despite being built.
- Updates `CLAUDE.md` and `README.md` to describe the page as "unlisted" rather than "excluded from build".

Supersedes #75, which took the heavier approach of excluding the page from the build entirely. The new approach is reversible by restoring the nav and 404 links and removing the `noindex` meta and sitemap filter.

## Test plan
- [x] `npm run build` — 8 pages built, `/pricing/index.html` present
- [x] Built HTML contains `<meta name="robots" content="noindex, nofollow">` on `/pricing/`
- [x] `dist/sitemap-0.xml` does not list `/pricing/`
- [ ] After deploy: visit `https://imbra.io/pricing/` directly — page loads
- [ ] After deploy: confirm nav has no Pricing link on desktop and mobile
- [ ] After deploy: confirm `https://imbra.io/sitemap-0.xml` excludes `/pricing/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)